### PR TITLE
Fix damping ratio exception

### DIFF
--- a/src/matching_assessment.py
+++ b/src/matching_assessment.py
@@ -261,7 +261,7 @@ def compute_suite_rotdnn_spectra(suite_dir, periods, trt,
     Calculate RotDnn Response Spectra for each record in a given suite of
     acceleration time-histories from ASC/SZ regions.
     """
-    print("Calculting " + trt + f" RotD{percentile:.0f}-component spectra...")
+    print("Calculating " + trt + f" RotD{percentile:.0f}-component spectra...")
 
     dir_list = os.listdir(suite_dir)
     manager = mp.Manager()

--- a/src/matching_assessment.py
+++ b/src/matching_assessment.py
@@ -188,8 +188,12 @@ def detect_damping_ratio(suite_dir):
 
     damping = []
     for target in targets:
-        damping.append(
-            float(target[target.find('(') + 1:target.find('%')]) / 100)
+        try:
+            damping.append(
+                float(target[target.find('(') + 1:target.find('%')]) / 100)
+        except ValueError:
+            raise ValueError('Input valid damping ratio value!')
+
     if len(set(damping)) != 1:
         raise ValueError('Damping ratios in target files are inconsistent!')
     else:

--- a/src/matching_assessment.py
+++ b/src/matching_assessment.py
@@ -248,13 +248,6 @@ def _record_rotdnn(record, suite_dir, ALIASES, periods, damping_level,
     RotDnn_cgs = ims.rotdpp(record_acc_H1, dt, record_acc_H2, dt,
                             periods, percentile=percentile,
                             damping=damping_level, units='g')[0]
-    # # FOR WORKFLOW TESTING ONLY
-    # sax, say = ims.get_response_spectrum_pair(
-    #                 record_acc_H1, dt, record_acc_H2, dt,
-    #                 periods, damping=damping_level, units='g')
-    #
-    # # calculate GeoMean spectra for record pair, but result is in cgs units
-    # RotDnn_cgs = ims.geometric_mean_spectrum(sax, say)
 
     # convert to g units
     RotDnn_SA_g = conv(RotDnn_cgs["Pseudo-Acceleration"],

--- a/src/matching_assessment.py
+++ b/src/matching_assessment.py
@@ -213,8 +213,12 @@ def detect_percentile(suite_dir):
     
     percentile = []
     for target in targets:
-        percentile.append(float(target[target.lower().find('rotd') + 4:
+        try:
+            percentile.append(float(target[target.lower().find('rotd') + 4:
                         target.lower().find('target')]))
+        except ValueError:
+            raise ValueError('Input valid RotDnn value!')
+
     if len(set(percentile)) != 1:
         raise ValueError('Percentile in target files are inconsistent!')
     else:


### PR DESCRIPTION
Edit unnecessary and unexcepted code in damping ratio & percentile values in file names of target spectra.